### PR TITLE
Removed useless shebang

### DIFF
--- a/scrypt/scrypt.py
+++ b/scrypt/scrypt.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 import sys
 from ctypes import (


### PR DESCRIPTION
File is not executable and would fail anyway.

```
$ chmod +x scrypt.py
$ ./scrypt.py
Traceback (most recent call last):
  File "/home/jonny/fedora-scm/python-scrypt/scrypt-0.9.4/scrypt/./scrypt.py", line 46, in <module>
    _scryptenc_buf = _scrypt.exp_scryptenc_buf
                     ^^^^^^^
NameError: name '_scrypt' is not defined
```